### PR TITLE
fix(build): Change package name to match the constraints

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -50,14 +50,18 @@ function doBuild() {
 	local goarch=$2
 	local target=$3
 	local output=$4
+  local version=$5
+
+  dir=$output
+	name=$(echo $target | awk -F'/' '{ print $3 }')
+  binname=${name}_${version}_${goos}-${goarch}
 
 	echo "==> building for $goos $goarch"
 
-	dir=$output/$1-$2
-	if [ -e $dir ]; then
-		echo "    $dir exists, skipping build"
-		return
-	fi
+	# if [ -e $dir ]; then
+	# 	echo "    $dir exists, skipping build"
+	# 	return
+	# fi
 	echo "    output to $dir"
 
 	mkdir -p tmp-build
@@ -76,7 +80,6 @@ function doBuild() {
 	fi
 
 	# now zip it all up
-	binname=$(echo $target | awk -F'/' '{ print $3 }')
 	mkdir -p $dir
 	if  zip -r $dir/$binname.zip tmp-build/* > /dev/null; then
 		printDistInfo $binname
@@ -130,7 +133,7 @@ function buildWithMatrix() {
 	# build each os/arch combo
 	while read line
 	do
-		doBuild $line $gobin $output
+		doBuild $line $gobin $output $version
 	done < $matfile
 
 	mv dist.json $output/dist.json

--- a/build-go.sh
+++ b/build-go.sh
@@ -50,11 +50,11 @@ function doBuild() {
 	local goarch=$2
 	local target=$3
 	local output=$4
-  local version=$5
+	local version=$5
 
-  dir=$output
+	dir=$output
 	name=$(echo $target | awk -F'/' '{ print $3 }')
-  binname=${name}_${version}_${goos}-${goarch}
+	binname=${name}_${version}_${goos}-${goarch}
 
 	echo "==> building for $goos $goarch"
 

--- a/site/public/_js/_platform.js
+++ b/site/public/_js/_platform.js
@@ -18,7 +18,7 @@ function buildDownloadLink (id, version, os) {
   const osName = getOsName(os.family)
   const arch = getArch(osName, os.architecture)
 
-  return `${id}/${version}/${osName}-${arch}/${id}.zip`
+  return `${id}/${version}/${id}_${version}_${osName}-${arch}.zip`
 }
 
 module.exports = function run () {

--- a/site/public/_js/_platform.js
+++ b/site/public/_js/_platform.js
@@ -14,11 +14,17 @@ function getOsName (family) {
   return 'linux'
 }
 
+function getExt (os) {
+  if (os === 'windows') return 'zip'
+  return 'tar.gz'
+}
+
 function buildDownloadLink (id, version, os) {
   const osName = getOsName(os.family)
   const arch = getArch(osName, os.architecture)
+  const ext = getExt(osName)
 
-  return `${id}/${version}/${id}_${version}_${osName}-${arch}.zip`
+  return `${id}/${version}/${id}_${version}_${osName}-${arch}.${ext}`
 }
 
 module.exports = function run () {

--- a/site/public/index.jade
+++ b/site/public/index.jade
@@ -53,7 +53,7 @@ include ./_header.jade
                     th= architectureMap[p.name]
                     for arch, target in p.archs
                       td(colspan='#{colspan}')
-                        - link = data.releaseLink.replace(/^\//, '') + '/' + arch.link
+                        - link = data.releaseLink.replace(/^\//, '') + arch.link
                         a(href='#{link}')= targetMap[target]
 
 include ./_footer.jade

--- a/tasks/dist.js
+++ b/tasks/dist.js
@@ -5,6 +5,7 @@ const {join} = require('path')
 const mkdirp = require('mkdirp')
 const {series, each} = require('async')
 const del = require('del')
+const _ = require('lodash')
 
 const log = $.util.log
 
@@ -42,7 +43,7 @@ function writeSiteFiles (type, done) {
   fs.stat(join(RELEASE_PATH, type), (err, stats) => {
     if (err) return done(err)
 
-    if (stats.isDirectory()) {
+    if (stats.isDirectory() && !_.contains(['fonts'], type)) {
       getVersion(type, (err, version) => {
         if (err) return done(err)
 


### PR DESCRIPTION
This fixes the package names, but is still missing the switch to `.tar.gz` for some oses.

Ref #33 