### PR TITLE
feat: Setup code signing for all packages using opgenpgp

### DIFF
--- a/SIGNING.md
+++ b/SIGNING.md
@@ -1,0 +1,56 @@
+# Signing and Security
+
+In order to ensure that downloaded binaries are not compromised we provide
+two ways of checking the integrity of the downloaded files.
+
+In the following the reference to "tarball" means either a `zip` or `tar.gz` file
+depending on the target operating system.
+If not stated otherwise "key" refers to a public/private key pair usable for public
+key cryptography.
+
+## 1. `SHA512` Checksum
+
+After the tarball was created, [`gpg`](https://gnupg.org/) is used to generate
+the `SHA512` checksum of the tarball and put into a file called `$original_file.sha`.
+The command for doing this is
+
+```bash
+$ gpg --print-md SHA512 $original_file> > $original_file.sha
+```
+
+## 2. OpenPGP Compatible ASCII Armored Detached Signatures
+
+After the tarball is generated it is signed using one of the trusted developer keys.
+From that an OpenPGP compatible ASCII armored detached signature is created and
+put into a file `$original_file.asc`.
+The command for doing this is
+
+```bash
+$ gpg --armor --output $original_file.asc --detach-sig $original_file
+```
+
+## Trusted Developer Keys
+
+These keys are the ones used to sign tarballs and used to verify their integrity.
+
+### Required properties of the keys
+
+* The private key MUST be stored on seperate hardware than the computer used to sign
+  the release. For convenience something like a [YubiKey](https://www.yubico.com/)
+  is recommended.
+* The key must have a length of at least `2048` bits and of type RSA.
+* The public key MUST be uploaded to https://pgp.mit.edu/.
+* The full fingerprint MUST be listed on the distributions page.
+
+### Obtaining the public keys for verification
+
+The keys fingerprints are listed on the distributions page and the public keys
+can be downloaded from https://pgp.mit.edu/ using
+
+```bash
+$ gpg --keyserver pgpkeys.mit.edu --recv-key $figerprint
+```
+
+## Further Reading
+
+* [Apache Release Signing Document](https://www.apache.org/dev/release-signing.html)

--- a/build-go.sh
+++ b/build-go.sh
@@ -107,15 +107,24 @@ function doBuild() {
 		success=1
 	fi
 
-  local sign_name=$dir/$binname.`pkgType $goos`
-  gpg --armor --output $sign_name.asc --detach-sig $sign_name
+	local sign_name=$binname.`pkgType $goos`
+	gpg --armor --output $dir/$sign_name.asc --detach-sig $dir/$sign_name
 
-  if [ $? -ne 0 ]; then
-      warn "    failed to sign release"
-		  success=1
-  else
-      notice "    signed release!"
-  fi
+	if [ $? -ne 0 ]; then
+		warn "    failed to sign release"
+		success=1
+	else
+		notice "    signed release!"
+	fi
+
+	(cd $dir && gpg --print-md SHA512 $sign_name > $sign_name.sha)
+
+	if [ $? -ne 0 ]; then
+		warn "    failed to generate sha512 checksum"
+		success=1
+	else
+		notice "    generated sha512 checksum!"
+	fi
 
 	# output results to results table
 	echo $target, $goos, $goarch, $success >> $output/results

--- a/build-go.sh
+++ b/build-go.sh
@@ -107,6 +107,15 @@ function doBuild() {
 		success=1
 	fi
 
+  local sign_name=$dir/$binname.`pkgType $goos`
+  gpg --armor --output $sign_name.asc --detach-sig $sign_name
+
+  if [ $? -ne 0 ]; then
+      warn "    failed to sign release"
+		  success=1
+  else
+      notice "    signed release!"
+  fi
 
 	# output results to results table
 	echo $target, $goos, $goarch, $success >> $output/results

--- a/site/public/_about.md
+++ b/site/public/_about.md
@@ -27,10 +27,13 @@ $ gpg --verify go-ipfs.tar.gz.asc go-ipfs.tar.gz
 
 You will need to download the public key of the release managers, which are currently,
 
-* Friedel Ziegelmayer <dignifiedquire@gmail.com> [`27F50659`](https://pgp.mit.edu/pks/lookup?search=0x27F50659&op=vindex&fingerprint=on).
+* Friedel Ziegelmayer <dignifiedquire@gmail.com> [`E2C5 3DFE 7CBA 9864 38B9  88D9 0741 3B8A 27F5 0659`](https://pgp.mit.edu/pks/lookup?search=0xE2C53DFE7CBA986438B988D907413B8A27F50659&op=index&fingerprint=on&exact=on).
 
 The command for this is
 
 ```bash
 $ gpg --keyserver pgpkeys.mit.edu --recv-key <keyid>
 ```
+
+There is also a `file.sha` file for every package that contains the `sha512` checksum
+as an additional integrity check.

--- a/site/public/_about.md
+++ b/site/public/_about.md
@@ -16,3 +16,21 @@ page with,
 The `All Versions` link on each distribution shows directory listings for all the available versions, and a `versions` file ([example](http://dist.ipfs.io/go-ipfs/versions)). This file can be used by tools, such as [ipfs-update](#ipfs-update), to find all the available versions and download the latest.
 
 The directory listing of each version ([example](http://dist.ipfs.io/go-ipfs/v0.3.11)) has all the platform archives (`.zip` or `.tar.gz`), a `README.md` and a `dist.json` which describe the release for humans and machines. It is meant to be easily consumed and used by tools.
+
+##### Code Signing
+
+All releases are signed using [OpenPGP](http://www.openpgp.org/). You can verify this by running
+
+```bash
+$ gpg --verify go-ipfs.tar.gz.asc go-ipfs.tar.gz
+```
+
+You will need to download the public key of the release managers, which are currently,
+
+* Friedel Ziegelmayer <dignifiedquire@gmail.com> [`27F50659`](https://pgp.mit.edu/pks/lookup?search=0x27F50659&op=vindex&fingerprint=on).
+
+The command for this is
+
+```bash
+$ gpg --keyserver pgpkeys.mit.edu --recv-key <keyid>
+```

--- a/site/public/css/_component.less
+++ b/site/public/css/_component.less
@@ -103,16 +103,22 @@
     border-top: none;
     width: 50px;
 
-    a {
+    a.download {
       background: none;
-      display: block;
-      height: 100%;
-      width: 100%;
       text-align: center;
       transition: background 0.2s ease-in-out;
       line-height: 3 * @baseLineHeight;
     }
 
+    a.signature {
+      display: inline;
+    }
+
+    a:hover {
+      .linkUnderlines(@baseBlue, @white);
+    }
+
+    &:hover,
     &:hover a,
     a:hover {
       color: @white;

--- a/site/public/index.jade
+++ b/site/public/index.jade
@@ -54,6 +54,8 @@ include ./_header.jade
                     for arch, target in p.archs
                       td(colspan='#{colspan}')
                         - link = data.releaseLink.replace(/^\//, '') + arch.link
-                        a(href='#{link}')= targetMap[target]
+                        a.download(href='#{link}')= targetMap[target]
+                        | &nbsp;
+                        a.signature(href='#{link}.asc') [sig]
 
 include ./_footer.jade


### PR DESCRIPTION
**Update**: Added process references
**Update**: Added sha512 checksums

I've setup a pgp on my yubikey that is used for the code signing process. This process generates pgp signatures for every single tar/zip file and adds them to directory. As in the description explained they can be verified by running 

``` bash
$ gpg --verify file.tar.gz.asc file.tar.gz
```

if the key is present. 

Ref https://github.com/ipfs/go-ipfs/issues/957
## References
- The distribution of keys is modeled after https://developers.yubico.com/Software_Projects/Software_Signing.html 
- The signature generation is modeled after the release signing process of the apache foundation: https://www.apache.org/dev/release-signing.html
## Key Management
### Setup
- Every developer (currently me) who has the right to sign releases generates a pgp key, stored on dedicated hardware like a yubikey
- The fingerprint is added to dist.ipfs.io
- The public key is uploaded to https://pgp.mit.edu/ for ease of distribution
### Verification
- The user who downloads from dist.ipfs.io can fetch the listed public keys listed from https://pgp.mit.edu/ and add them to their keyring
- The user downloads the signature + file
- The user uses pgp + signature to verify the file 
## Checksums

In addition to the signatures there are also `file.sha` files containing the `sha512` checksum of the packages.
