### PR TITLE
remove taxonomies

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -3,6 +3,9 @@ relativeurls = true
 languageCode = "en-us"
 title = "IPFS Distributions"
 
+# No tags/categories
+taxonomies = {}
+
 [params]
 [params.targetMap]
 386 = "32-bit"


### PR DESCRIPTION
This prevents hugo from generating the tags/categories directories.