### PR TITLE
add arm64 support

### DIFF
--- a/dists/go-ipfs/build_matrix
+++ b/dists/go-ipfs/build_matrix
@@ -6,5 +6,6 @@ freebsd arm
 linux 386
 linux amd64
 linux arm
+linux arm64
 windows 386
 windows amd64

--- a/dists/go-ipfs/mkdist.js
+++ b/dists/go-ipfs/mkdist.js
@@ -20,9 +20,10 @@ mkdist({
       {id: 'windows', name: 'Windows Binary (.zip)', browser: 'Windows'}
     ],
     archs: [
-      {id: '386',   name: '32 bit', browser: '32'},
-      {id: 'amd64', name: '64 bit', browser: '64'},
-      {id: 'arm',   name: 'ARM',    browser: 'ARM'}
+      {id: '386',     name: '32 bit',       browser: '32'},
+      {id: 'amd64',   name: '64 bit',       browser: '64'},
+      {id: 'arm',     name: 'ARM',          browser: 'ARM'},
+      {id: 'arm64',   name: 'ARM (64 bit)', browser: 'ARM64'}
     ]
   }
 })

--- a/dists/gx-go/build_matrix
+++ b/dists/gx-go/build_matrix
@@ -6,5 +6,6 @@ freebsd arm
 linux 386
 linux amd64
 linux arm
+linux arm64
 windows 386
 windows amd64

--- a/dists/gx/build_matrix
+++ b/dists/gx/build_matrix
@@ -6,5 +6,6 @@ freebsd arm
 linux 386
 linux amd64
 linux arm
+linux arm64
 windows 386
 windows amd64


### PR DESCRIPTION
go-ipfs actually "supports" (it builds, at least) arm64. However, we don't currently build it.

Is this the correct way to add support?