### PR TITLE
Publish checksums for every artifact

### DIFF
--- a/deps-check.sh
+++ b/deps-check.sh
@@ -5,6 +5,10 @@ function fail() {
 	exit 1
 }
 
+(ipfs version > /dev/null 2>&1) || (fail "Missing ipfs, please install it :-)")
+(awk --version > /dev/null 2>&1) || (fail "Missing awk, please install it")
+(date | shasum -a 512 - > /dev/null 2>&1) || (fail "Missing shasum with sha512 support, please install it")
+
 (hugo version > /dev/null 2>&1) || (fail "Missing hugo, please see https://gohugo.io/")
 
 (node --version > /dev/null 2>&1) || (fail "Missing node.js, please see https://nodejs.org/")

--- a/deps-check.sh
+++ b/deps-check.sh
@@ -17,4 +17,6 @@ function fail() {
 
 (yarn --version > /dev/null 2>&1) || (fail "Missing yarn, please install with `npm i -g yarn`")
 
+(jq --version > /dev/null 2>&1) || (fail "Missing jq, please see https://stedolan.github.io/jq/")
+
 exec yarn


### PR DESCRIPTION
This PR aims to close https://github.com/ipfs/distributions/issues/152 by exposing CID and additionally generating a plain SHA512 hash for every artifact of new releases.


### Rationale 

I had a short chat with someone (sorry, forgot the name :() about things that we could improve as an open source project to make it easier to package our software.

Number one issue was that we do not publish checksums and package managers can't verify downloads without additional orchestration. This makes package maintainer's work harder than it should be.

I mentioned all our artifacts are content-addressed and it is possible to get CID for every file but there is a good argument about learning curve of IPFS concepts and multihash/cids not being supported by default userland tools in unix-like systems (yet), while things like `shasum` being usually around. 

### Details 

This PR exposes two new values in two places:
- in file hierarchy, as additional files with self-describing extension:
  - `releases/<dist>/<version>/<dist>_<version>_<platform>.tar.gz.cid`
  - `releases/<dist>/<version>/<dist>_<version>_<platform>.tar.gz.sha512`
- in `releases/<dist>/<version>/dist.js` as additional fields named `cid` and `sha512`:
  ```diff
  "amd64": {
            "link": "/go-ipfs_v0.4.17_linux-amd64.tar.gz",
  +          "cid": "QmSmogJPQKUbDtvtxBsbstE4RtX7u1RRoApCyQgzj9UvD7",
  +          "sha512": "27aa376e0a542aefadc643503bf3f95c4255fbdeff0f6522bba0fa3f2b9145a30c246d7e9c2e2d260381b8d7b9b96dbc0f29649e2732af8ddce204c205a2f770"
           },
  ```

Flat files enable bulk verification via simple shell scripts or just plain `shasum -c *.sha512`.
Fields in `dist.js` enable more sophisticated setups to do the same.

### How to test locally

```bash 
  # fetch historical releases of go-ipfs
$ make go-ipfs
$ cd dists/go-ipfs
  # remove last release 
$ rm -rf ../../releases/go-ipfs/v0.4.17
  # rebuild v0.4.17
$ bash ../../build-go.sh go-ipfs github.com/ipfs/go-ipfs/cmd/ipfs versions
  # inspect generated artifacts
$ ls ../../releases/go-ipfs/v0.4.17/
$ view ../../releases/go-ipfs/v0.4.17/dist.json
```

### What about historical releases?

Due to the way we fetch historical data from IPNS those changes will be applied only to new releases.  Adding this additional metadata to historical archives requires additional work and QA and if it is really needed it can be tackled in a separate PR, so this one can be merged before go-ipfs v0.4.18 is released. 