### PR TITLE
Added executable bit on install.sh for tar.

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -134,6 +134,9 @@ function bundleDist() {
 		return $?
 		;;
 	tar.gz)
+		if [ -f "$build_dir/install.sh" ]; then
+			chmod +x $build_dir/install.sh
+		fi
 		tar czf $name.tar.gz $build_dir/*
 		return $?
 		;;


### PR DESCRIPTION
Tar is an unix friendly archive and allow to keep unix permission, so adding this is suposed install.sh to be executable right after `tar xf`.