### PR TITLE
Tweak footer template to correctly space around links

### DIFF
--- a/site/layouts/partials/footer.amber
+++ b/site/layouts/partials/footer.amber
@@ -2,9 +2,9 @@ footer.d-footer
   div.container
     div.row
       | © IPFS Community |
-      | Except as
-      a[href="http://ipn.io/legal/policies"]  noted
-      | , content licensed
-      a[href="https://creativecommons.org/licenses/by/3.0/"]  CC-BY 3.0
-      |  | Source on
-      a[href="https://github.com/ipfs/distributions"]  Github
+      | Except as 
+      a[href="http://ipn.io/legal/policies"] noted
+      | , content licensed 
+      a[href="https://creativecommons.org/licenses/by/3.0/"] CC-BY 3.0
+      | Source on 
+      a[href="https://github.com/ipfs/distributions"] Github


### PR DESCRIPTION
The spacing on the footer of dists.ipfs.io seems off. I think the template is eating some double spaces, and does not add spaces for line breaks. Should slightly improve readability/accessibility.

> © IPFS Community | Except as[noted](), content licensed[CC-BY 3.0]() | Source on[Github]()

Screenshot:
<img width="526" alt="Screenshot 2019-04-12 13 24 41" src="https://user-images.githubusercontent.com/5170/56064291-2d9d3880-5d61-11e9-98e8-1b131c0aadc3.png">
