### PR TITLE
build using go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ www
 *.swp
 **/get_output
 **/build-log
+**/go.sum
+**/go.mod
 /versions
 
 site/static/*.js


### PR DESCRIPTION
This way _all_ the paths are consistent in the compiled binary. I.e., we can finally use plugins.