### PR TITLE
Fix: set goos and goarch correctly

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -101,7 +101,7 @@ function doBuild() {
 	local output=$4
 	local version=$5
 
-  local dir name binname
+	local dir name binname
 
 	dir="$output"
 	name="$(basename "$(pwd)")"
@@ -223,7 +223,7 @@ function buildWithMatrix() {
 	# build each os/arch combo
 	while read -r line
 	do
-		doBuild "$line" "$package" "$output" "$version"
+		doBuild ${line} "$package" "$output" "$version"
 	done < "$matfile"
 
 	# build the source

--- a/build-go.sh
+++ b/build-go.sh
@@ -221,9 +221,9 @@ function buildWithMatrix() {
 	printBuildInfo "$commit" > "$output/build-info"
 
 	# build each os/arch combo
-	while read -r line
+	while read -r goos goarch
 	do
-		doBuild ${line} "$package" "$output" "$version"
+		doBuild "$goos" "$goarch" "$package" "$output" "$version"
 	done < "$matfile"
 
 	# build the source


### PR DESCRIPTION
The shell linter thing must have broken this.