### PR TITLE
feat: build on openbsd

### DIFF
--- a/dists/fs-repo-migrations/build_matrix
+++ b/dists/fs-repo-migrations/build_matrix
@@ -3,8 +3,12 @@ darwin amd64
 freebsd 386
 freebsd amd64
 freebsd arm
+openbsd 386
+openbsd amd64
+openbsd arm
 linux 386
 linux amd64
 linux arm
+linux arm64
 windows 386
 windows amd64

--- a/dists/go-ipfs/build_matrix
+++ b/dists/go-ipfs/build_matrix
@@ -3,6 +3,9 @@ darwin amd64
 freebsd 386
 freebsd amd64
 freebsd arm
+openbsd 386
+openbsd amd64
+openbsd arm
 linux 386
 linux amd64
 linux arm

--- a/site/config.toml
+++ b/site/config.toml
@@ -16,5 +16,6 @@ arm64 = "ARM-64"
 [params.architectureMap]
 darwin = "macOS Binary"
 freebsd = "FreeBSD Binary"
+openbsd = "OpenBSD Binary"
 linux = "Linux Binary"
 windows = "Windows Binary"


### PR DESCRIPTION
1. Build go-ipfs 0.5.0 and 0.5.1 on openbsd (and linux arm64).
2. Importantly, build the latest migrations on openbsd so upgrading openbsd machines doesn't fail.

HASH: QmXuKUDChMXkcq36CbaggvY3UaAtgpi7yyoAiNy5VD9Dfr

fixes #100