### PR TITLE
feat: switch to building using -trimpath instead of using the asm and gc trimpath flags

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -88,8 +88,7 @@ function goBuild() {
       output="$(pwd)/$(basename "$package")$(go env GOEXE)"
 
       go build -o "$output" \
-	 -asmflags=all=-trimpath="$GOPATH" \
-	 -gcflags=all=-trimpath="$GOPATH"  \
+	 -trimpath \
 	 "${package}"
   )
 }


### PR DESCRIPTION
This will effect future builds. While everything should be fine please be careful to run `ipfs object diff /ipns/dist.ipfs.io /ipfs/HASH` to ensure you haven't replaced any old binaries.

@hsanjuan @Stebalien @jessicaschilling 