### PR TITLE
fix: avoid wrapping app name in dowload btn

### DIFF
--- a/site/assets/less/base.less
+++ b/site/assets/less/base.less
@@ -91,6 +91,10 @@ a:hover {
   float: right;
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
 code {
   color: @redMuted;
   font-size: 95%;

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -48,7 +48,9 @@
                   <div class="d-component-desc-body">{{ $data.description | markdownify }}</div>
                 </div>
                 <div class="d-component-asset col-md-4 offset-md-1">
-                  <a href="" data-id="{{ $key }}" data-version="{{ $data.version }}" class="d-component-download-btn btn btn-primary">Download {{ $key }}</a>
+                  <a href="" data-id="{{ $key }}" data-version="{{ $data.version }}" class="d-component-download-btn btn btn-primary">Download 
+                    <span class="nowrap">{{ $key }}</span>
+                  </a>
                   <div class="d-component-download-alternative">
                     <div class="d-component-arch"></div>
                     <div class="d-component-not">Not your platform? See below for alternatives</div>


### PR DESCRIPTION
ui tweak to avoid breaking the distribution name in the download button

| before | after |
|--------|------|
| <img width="1328" alt="Screenshot 2020-10-23 at 19 59 21" src="https://user-images.githubusercontent.com/58871/97043404-531c1c80-156a-11eb-9c8a-9fe2cbc6c884.png"> | <img width="1328" alt="Screenshot 2020-10-23 at 19 59 12" src="https://user-images.githubusercontent.com/58871/97043481-76df6280-156a-11eb-9626-61647e13f0ed.png">



License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>