### PR TITLE
remove darwin 386 support as it is not supported by Go 1.15+

### DIFF
--- a/dists/fs-repo-migrations/build_matrix
+++ b/dists/fs-repo-migrations/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/go-ipfs/build_matrix
+++ b/dists/go-ipfs/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/gx-go/build_matrix
+++ b/dists/gx-go/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/gx/build_matrix
+++ b/dists/gx/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-cluster-ctl/build_matrix
+++ b/dists/ipfs-cluster-ctl/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-cluster-follow/build_matrix
+++ b/dists/ipfs-cluster-follow/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-cluster-service/build_matrix
+++ b/dists/ipfs-cluster-service/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-ds-convert/build_matrix
+++ b/dists/ipfs-ds-convert/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-pack/build_matrix
+++ b/dists/ipfs-pack/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-see-all/build_matrix
+++ b/dists/ipfs-see-all/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipfs-update/build_matrix
+++ b/dists/ipfs-update/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64

--- a/dists/ipget/build_matrix
+++ b/dists/ipget/build_matrix
@@ -1,4 +1,3 @@
-darwin 386
 darwin amd64
 freebsd 386
 freebsd amd64


### PR DESCRIPTION
Darwin 386 is not supported by Go 1.15+ (https://github.com/golang/go/issues/34749) so it should be removed from the build matrix of the binaries.