### PR TITLE
fix: allow writing statuses on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,8 @@ jobs:
   persist:
     runs-on: "ubuntu-latest"
     needs: sign-macos
+    permissions:
+      statuses: write
     steps:
       - uses: actions/checkout@v2
       - name: Retrieve signed artifacts


### PR DESCRIPTION
This aims to restore "Preview on IPFS" badges broken by github's security hardening this year

Ref.
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions