### PR TITLE
fix(ci): more robust cluster connect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: CI
 
 on:
-  #  push:
-  #  branches:
-  #    - master
-  #pull_request:
-  #  branches:
-  #    - master
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       dist_root:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  #  push:
+  #  branches:
+  #    - master
+  #pull_request:
+  #  branches:
+  #    - master
   workflow_dispatch:
     inputs:
       dist_root:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: Nightly
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       dist_root:
@@ -12,8 +13,8 @@ on:
 
 env:
  DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.io' }} # content root used for calculating diff to build
- GO_IPFS_VER: 'v0.9.1'           # go-ipfs daemon used for chunking and applying diff
- CLUSTER_CTL_VER: 'v0.14.0'      # ipfs-cluster-ctl used for pinning
+ GO_IPFS_VER: 'v0.10.0'           # go-ipfs daemon used for chunking and applying diff
+ CLUSTER_CTL_VER: 'v0.14.1'      # ipfs-cluster-ctl used for pinning
 
 concurrency:
   group: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,6 @@
 name: Nightly
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       dist_root:

--- a/scripts/ci/pin-to-cluster.sh
+++ b/scripts/ci/pin-to-cluster.sh
@@ -11,6 +11,7 @@ ipfs-cluster-ctl --enc=json \
     "$PIN_CID"
 echo "::endgroup::"
 
+# TODO: below can now be replaced with ipfs-cluster-ctl --wait now (https://github.com/ipfs/ipfs-cluster/blob/v0.14.1/CHANGELOG.md#v0141---2021-08-18)
 echo "::group::waiting until pinned"
     while true; do
     ipfs-cluster-ctl --enc=json \

--- a/scripts/ci/setup-ipfs.sh
+++ b/scripts/ci/setup-ipfs.sh
@@ -29,7 +29,7 @@ sudo sysctl -w net.core.rmem_max=2500000
 
 # init ipfs
 echo "::group::Set up IPFS daemon"
-    ipfs init --profile flatfs,server,test,randomports,lowpower
+    ipfs init --profile flatfs,server,randomports,lowpower
     # make flatfs async for faster ci
     new_config=$( jq '.Datastore.Spec.mounts[0].child.sync = false' ~/.ipfs/config) && echo "${new_config}" > ~/.ipfs/config
     # restore deterministic port (changed by test profile)
@@ -46,8 +46,8 @@ echo "::group::Preconnect to cluster peers"
         --basic-auth "${CLUSTER_USER}:${CLUSTER_PASSWORD}" \
         peers ls > cluster-peers-ls
     for maddr in $(jq -r '.[].ipfs.addresses[]?' cluster-peers-ls); do
-        ipfs swarm peering add "$maddr" || continue
-        ipfs swarm connect "$maddr" || continue
+        ipfs swarm peering add $maddr || continue
+        ipfs swarm connect $maddr || continue
     done
     echo '-> manual connect to cluster.ipfs.io'
     ipfs swarm connect /dnsaddr/cluster.ipfs.io


### PR DESCRIPTION
This PR aims to fix nightly builds: bumps binaries used for build and restores use of bootstrappers, so there is a fallback in case cluster is down or in a weird state.

(CI is green, failures are from previous runs)