### PR TITLE
fix: don't fail glibc check for statically linked binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN asdf install
 ENV IPFS_PATH=/asdf/.ipfs
 RUN mkdir -p ${IPFS_PATH} && echo "/ip4/127.0.0.1/tcp/5001" > ${IPFS_PATH}/api
 
-RUN go install github.com/guseggert/glibc-check/cmd/glibc-check@v0.0.0-20211020180227-964e8f06bf27 && asdf reshim
+RUN go install github.com/guseggert/glibc-check/cmd/glibc-check@v0.0.0-20211130152056-cb76aed949fd && asdf reshim
 
 ARG CACHEBUST=undefined
 USER root


### PR DESCRIPTION
Some simple binaries (e.g. that don't use the "net" package) are
statically linked by the Go compiler, so don't have symbol tables,
which caused glibc-check to barf and the build to fail. This updates
glibc-check to a newer version that won't fail if there is no symbol table.