### PR TITLE
fix: update nightly status on commits

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,13 +75,6 @@ jobs:
               console.log('commented on existing open issue', created)
               link = created.data.html_url
             }
-            await github.repos.createCommitStatus({ ...opts,
-              sha: '${{ github.sha }}',
-              state: 'error',
-              target_url: link,
-              context: 'Problem with ${{ matrix.dist_name }}',
-              description: 'See details in the linked issue'
-            })
       - name: Inspect git status and contents of ./releases
         run: git status && ls -Rhl ./releases
       - name: Read CID of updated DAG


### PR DESCRIPTION
Problem – https://github.com/ipfs/distributions/issues/531 got fixed, but the "Problem with" message on commit remains: 

>  ![2021-12-15_22-12](https://user-images.githubusercontent.com/157609/146265676-108a6401-ac0a-4a23-99f9-72505da08ded.png)

