### PR TITLE
fix(ci): stabilize setup-ipfs step

### DIFF
--- a/.github/actions/setup-ipfs/action.yml
+++ b/.github/actions/setup-ipfs/action.yml
@@ -29,12 +29,12 @@ runs:
           --basic-auth "$CLUSTER_USER:$CLUSTER_PASSWORD" \
           peers ls > cluster-peers-ls
         for maddr in $(jq -r '.[].ipfs.addresses[]?' cluster-peers-ls); do
-          ipfs swarm peering add $maddr || continue
-          ipfs swarm connect $maddr || continue
+          ipfs swarm peering add $maddr &
+          ipfs swarm connect $maddr &
         done
       shell: bash
     - name: Manual connect to cluster.ipfs.io
-      run: ipfs swarm connect /dnsaddr/ipfs-nodes.cluster.ipfs.io || true
+      run: ipfs swarm connect /dnsaddr/ipfs-nodes.cluster.ipfs.io &
       shell: bash
     - name: List swarm peers
       run: ipfs swarm peers

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ on:
 
 env:
  DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.io' }} # content root used for calculating diff to build
- GO_IPFS_VER: 'v0.10.0-rc2'           # go-ipfs daemon used for chunking and applying diff
- CLUSTER_CTL_VER: 'v0.14.0'      # ipfs-cluster-ctl used for pinning
+ GO_IPFS_VER: 'v0.11.0'          # go-ipfs daemon used for chunking and applying diff
+ CLUSTER_CTL_VER: 'v0.14.4'      # ipfs-cluster-ctl used for pinning
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
         uses: ./.github/actions/setup-ipfs
-        timeout-minutes: 5
+        timeout-minutes: 30
       - name: Build any new ./releases
         run: ./dockerized make all_dists
       - name: Inspect git status and contents of ./releases
@@ -116,7 +116,7 @@ jobs:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
         uses: ./.github/actions/setup-ipfs
-        timeout-minutes: 5
+        timeout-minutes: 30
       - run: ./dockerized make publish
       - run: git status
       - name: Read CID of updated DAG

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
         uses: ./.github/actions/setup-ipfs
-        timeout-minutes: 5
+        timeout-minutes: 30
       - run: cd ./dists/${{ matrix.dist_name }} && make nightly
       - run: ./dockerized make publish
       - name: Create issue if build failed


### PR DESCRIPTION
This PR stabilizes nightly builds:
- makes preconnect to cluster peers async and best-effort (solving **Problem 1**)
- bumps timeout to 30m as downloading binaries from dist.ipfs.io may take  longer when under load. (solving **Problem 2**)

### Problem 1

Our nightlies timeout now and then because connecting to one of the cluster peers takes a long time, and that blocks and timeouts an entire build. 

For example: 

- https://github.com/ipfs/distributions/runs/5001510377?check_suite_focus=true#step:3:439 

We don't need to connect to all of them, and not all DNSAddr TXT records need to be valid.

### Problem 2

Secondly, `setup-ipfs` stage sometimes fails because it can't fetch go-ipfs binary from dist.ipfs.io (and there is a timeout of 5m around that):

- https://github.com/ipfs/distributions/runs/5026194679?check_suite_focus=true#step:4:111

