### PR TITLE
fix: brew tap mitchellh/gon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,13 @@ jobs:
         run: ls -Rhl ./releases || echo "No ./releases"
       - name: Install gon via HomeBrew for code signing and app notarization
         run: |
+          # workaround for https://github.com/mitchellh/gon/issues/56
+          pushd .
+          cd /usr/local/Homebrew
+          git fetch origin tag 3.3.9 --no-tags
+          git checkout 3.3.9
+          popd
+          # /workaround
           brew tap mitchellh/gon
           brew install ipfs coreutils gawk gnu-sed jq mitchellh/gon/gon
           ipfs init --profile test # needed for calculating NEW_CID later


### PR DESCRIPTION
This PR should fix macOS signing with mitchellh/gon by applying a workaround for https://github.com/mitchellh/gon/issues/56

![HAhaa](https://user-images.githubusercontent.com/157609/158891895-622fb24f-a33c-4a62-9676-ba3aab2275c5.png)
