### PR TITLE
feat: update nightly & signal the ipdx team on failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
             let link
             if (response.data.items.length === 0) {
               const created = await github.issues.create({ ...opts, title, body,
-                labels: ['kind/bug', 'need/triage']
+                labels: ['kind/bug', 'need/triage', 'team/ipdx']
               })
               console.log('no open issues, created a new one', created)
               link = created.data.html_url

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ all: deps releases all_dists site
 
 DISTS = $(notdir $(wildcard dists/*))
 
-NDISTS = $(DISTS:%=nightly-%)
+NIGHTLY_IGNORED := $(shell cat ignored-during-nightly)
+DISTS_FILTERED = $(filter-out $(NIGHTLY_IGNORED),$(DISTS))
+NDISTS = $(DISTS_FILTERED:%=nightly-%)
 
 .PHONY: all all_dists deps nightly
 all_dists: $(DISTS)

--- a/ignored-during-nightly
+++ b/ignored-during-nightly
@@ -1,0 +1,10 @@
+fs-repo-0-to-1
+fs-repo-1-to-2
+fs-repo-2-to-3
+fs-repo-3-to-4
+fs-repo-4-to-5
+fs-repo-5-to-6
+fs-repo-6-to-7
+fs-repo-7-to-8
+fs-repo-8-to-9
+fs-repo-9-to-10


### PR DESCRIPTION

- Tag the ipdx team when the nightly build fails,
- Skip nightly build for legacy code, use the `ignored-during-nightly` list of files,
- Use go version 1.17 for build, that should fix the current failure with quic-go