### PR TITLE
fix: respect ignored-during-nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,8 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: awk 'NR == FNR {f1[$0] = 1; next}; !($0 in f1)' ignored-during-nightly <(ls ./dists -1) > nightlies-to-run
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(jq -nc '$ARGS.positional' --args $(ls ./dists -1))"
+        run: echo "::set-output name=matrix::$(jq -nc '$ARGS.positional' --args $(cat nightlies-to-run))"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 

--- a/ignored-during-nightly
+++ b/ignored-during-nightly
@@ -9,3 +9,5 @@ fs-repo-7-to-8
 fs-repo-8-to-9
 fs-repo-9-to-10
 go-ipfs
+gx
+gx-go


### PR DESCRIPTION
The file was used only in Makefiles, but the CI still created a job for
each dist, which was wasteful and noisy:

| Before | After |
| ---- | ---- |
| ![2022-07-08_15-34](https://user-images.githubusercontent.com/157609/178002371-35b19302-7e3c-4901-bf82-fdfa11afd74c.png) |  ![2022-07-08_15-31](https://user-images.githubusercontent.com/157609/178002004-21a79601-57bf-45d4-a55f-89bb43ab451e.png) |


Closes #739