### PR TITLE
fix: link to legacy go-ipfs releases

### DIFF
--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -77,8 +77,14 @@
                     </li>
                     <li>
                       <i class="ion-ios-albums-outline"></i>
-                      <a class="d-component-actions-versions" href="{{ $key }}">All Versions</a>
+                      <a class="d-component-actions-versions" href="{{ $key }}">All Versions{{ if eq "kubo" $key }}<small style="color: var(--gray)"> (kubo)</small>{{ end }}</a>
                     </li>
+                    {{ if eq "kubo" $key }}
+                    <li>
+                      <i class="ion-ios-albums-outline"></i>
+                      <a class="d-component-actions-versions" href="go-ipfs">All Versions <small style="color: var(--gray)"> (go-ipfs)</small></a>
+                    </li>
+                    {{ end }}
                     <li>
                       <i class="ion-bug"></i>
                       <a class="d-component-actions-issues"


### PR DESCRIPTION
Right now there is no link on the website to find package with legacy go-ipfs releases.

I propose we just link to both new and old release lists:

### Preview

>  ![2022-07-08_16-50](https://user-images.githubusercontent.com/157609/178017962-5fed7609-7447-4425-8856-540cb5f556a5.png)


Closes #738