### PR TITLE
refactor: move to dist.ipfs.tech

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ on:
       dist_root:
         description: 'DIST_ROOT'
         required: true
-        default: '/ipns/dist.ipfs.io'
+        default: '/ipns/dist.ipfs.tech'
 
 env:
- DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.io' }} # content root used for calculating diff to build
+ DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
  GO_IPFS_VER: 'v0.13.0'          # go-ipfs daemon used for chunking and applying diff
  CLUSTER_CTL_VER: 'v1.0.1'       # ipfs-cluster-ctl used for pinning
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,12 +6,12 @@ on:
       dist_root:
         description: 'DIST_ROOT'
         required: true
-        default: '/ipns/dist.ipfs.io'
+        default: '/ipns/dist.ipfs.tech'
   schedule:
     - cron: '0 5 * * *' # UTC
 
 env:
- DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.io' }} # content root used for calculating diff to build
+ DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
  GO_IPFS_VER: 'v0.13.0'          # go-ipfs daemon used for chunking and applying diff
  CLUSTER_CTL_VER: 'v1.0.1'      # ipfs-cluster-ctl used for pinning
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GO_IPFS_VER
 RUN apt-get update -q && apt-get install -y git curl gnupg jq build-essential gawk zip tzdata && \
     ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
     dpkg-reconfigure --frontend noninteractive tzdata
-RUN curl -s "https://dist.ipfs.io/go-ipfs/${GO_IPFS_VER}/go-ipfs_${GO_IPFS_VER}_linux-amd64.tar.gz" | tar vzx -C /usr/local/bin/ go-ipfs/ipfs --strip-components=1
+RUN curl -s "https://dist.ipfs.tech/go-ipfs/${GO_IPFS_VER}/go-ipfs_${GO_IPFS_VER}_linux-amd64.tar.gz" | tar vzx -C /usr/local/bin/ go-ipfs/ipfs --strip-components=1
 
 RUN adduser --shell /bin/bash --home /asdf --disabled-password --gecos asdf asdf --uid $USER_UID
 ENV PATH="${PATH}:/asdf/.asdf/shims:/asdf/.asdf/bin"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # IPFS distributions
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.io/)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.tech/)
 [![](https://img.shields.io/badge/matrix%20chat-%23lobby:ipfs.io-blue.svg?style=flat-square)](https://matrix.to/#/#lobby:ipfs.io )
 
-> Source for building https://dist.ipfs.io
+> Source for building https://dist.ipfs.tech
 
 **Table of Contents**
 
@@ -74,7 +74,7 @@ and
 
 ## Usage
 
-Add a new version or a new distribution with `./dist.sh` then let CI run `make publish` to update DNSLink at dist.ipfs.io.
+Add a new version or a new distribution with `./dist.sh` then let CI run `make publish` to update DNSLink at dist.ipfs.tech.
 
 ### Adding a version
 
@@ -91,12 +91,12 @@ Example:
 > ./dist.sh add-version fs-repo-99-to-100 v1.0.1
 ```
 
-To produce a signed, **official build** for use in DNSLink at `dist.ipfs.io`:
+To produce a signed, **official build** for use in DNSLink at `dist.ipfs.tech`:
 
 1. Run `./dist.sh add-version` locally.
 2. Commit created changes to `dists/<dist>` and open a PR against `ipfs/distributions`.
 3. Wait for Github Action to finish PR build. It runs `./dockerized` build, then signs macOS binaries and spits out updated root CID at the end.
-4. If everything looks good, merge PR and wait for CI running on `master` to update the DNSlink at `dist.ipfs.io`.
+4. If everything looks good, merge PR and wait for CI running on `master` to update the DNSlink at `dist.ipfs.tech`.
 
 ### Adding a new (go) distribution
 
@@ -125,23 +125,20 @@ To produce a CID (`<NEW_HASH>`) that includes binaries for all versions defined 
 > make publish
 ```
 
-- This will build any new binaries defined by dist and the website to the `releases` dir, add it to ipfs and patch it into the existing dag for the published `/ipns/dist.ipfs.io`.
+- This will build any new binaries defined by dist and the website to the `releases` dir, add it to ipfs and patch it into the existing DAG for the published `/ipns/dist.ipfs.tech`.
 - Versions that are already present on the website will be reused, speeding up the build.
-- Updated CID (`<NEW_HASH>`) will be printed at the end. That's the new hash for `dists.ipfs.io`. We also append it to a file called `versions` in the repo root (*not* checked into git).
+- Updated CID (`<NEW_HASH>`) will be printed at the end. That's the new hash for `dist.ipfs.tech`. We also append it to a file called `versions` in the repo root (*not* checked into git).
 
 After the local build is done, make a quick inspection:
 
 2. Load the dists website in your browser to make sure everything looks right: `http://localhost:8080/ipfs/<NEW_HASH>`.
-3. Compare `<NEW_HASH>` with the current `dists.ipfs.io` to make sure nothing is amiss: `ipfs object diff /ipns/dist.ipfs.io /ipfs/<NEW_HASH>`
+3. Compare `<NEW_HASH>` with the current `dist.ipfs.tech` to make sure nothing is amiss: `ipfs object diff /ipns/dist.ipfs.tech /ipfs/<NEW_HASH>`
 
 Finally,
 
 1. Commit your changes and make a PR. Specifically, the changes to `dists/<dist>/versions` and `dists/<dist>/current`.
 2. Wait for [Github Action](https://github.com/ipfs/distributions/actions/) on your PR to build **signed** binaries. `<NEW_SIGNED_HASH>` will be different than one from local build.
-3. Make a PR with an edit on [protocol/infra](https://github.com/protocol/infra/blob/master/dns/config/dist.ipfs.io.yaml) with `<NEW_SIGNED_HASH>` you got from the Github Action output and a link to the PR above.
-   - TODO: this step may be automated in the future - see the [discussion](https://github.com/ipfs/distributions/issues/372).
-
-If you have permission, you can just merge the PR, update the DNS, and then immediately, close the issue on ipfs/infrastructure. Ping someone on IRC.
+3. Confirm that [Github Action](https://github.com/ipfs/distributions/actions/) triggered by `master` branch push updated the DNSLink for `dist.ipfs.tech`.
 
 ## Background
 

--- a/build-go.sh
+++ b/build-go.sh
@@ -10,7 +10,7 @@ export GOPATH
 export GO111MODULE=on
 
 # Content path to use when looking for pre-existing release data
-DIST_ROOT=$(ipfs resolve "${DIST_ROOT:-/ipns/dist.ipfs.io}")
+DIST_ROOT=$(ipfs resolve "${DIST_ROOT:-/ipns/dist.ipfs.tech}")
 
 # normalize umask
 umask 022

--- a/dockerized
+++ b/dockerized
@@ -8,7 +8,7 @@ docker pull ubuntu:20.04
 docker build . -t distributions \
     --build-arg CACHEBUST=`date --iso-8601=date` \
     --build-arg USER_UID=$(id -u "$USER") \
-    --build-arg GO_IPFS_VER=${GO_IPFS_VER:-$(curl -s https://dist.ipfs.io/go-ipfs/versions | tail -n 1)} # match http api client version on CI
+    --build-arg GO_IPFS_VER=${GO_IPFS_VER:-$(curl -s https://dist.ipfs.tech/go-ipfs/versions | tail -n 1)} # match http api client version on CI
 
 # We use host networking as the build process assumes a fairly long-lived ipfs
 # node has the CIDs (we give them to the collab cluster to pin) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dist.ipfs.io",
+  "name": "dist.ipfs.tech",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dist.ipfs.io",
+      "name": "dist.ipfs.tech",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "dist.ipfs.io",
+  "name": "dist.ipfs.tech",
   "version": "1.0.0",
-  "description": "Source for building https://dist.ipfs.io.",
+  "description": "Source for building https://dist.ipfs.tech.",
   "main": "",
+  "private": true,
   "scripts": {
     "standard": "standard scripts/*.js site/assets/js/*.js",
     "lint": "npm run standard && shellcheck *.sh",

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -8,7 +8,7 @@ const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 require('make-promises-safe') // exit on error
 
-const DIST_ROOT = process.env.DIST_ROOT || '/ipns/dist.ipfs.io'
+const DIST_ROOT = process.env.DIST_ROOT || '/ipns/dist.ipfs.tech'
 const CHANGE_TYPE_ADD = 0
 const CHANGE_TYPE_REMOVE = 1
 const CHANGE_TYPE_MOD = 2

--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -4,7 +4,7 @@
 /*
  * Copy dist.json for the current version of each distribution to the hugo data dir.
  * Looks for a local releases/<dist>/<ver>/dist.json and fallsback to fetching the
- * current published one from dist.ipfs.io/<dist>/<ver>/dist.json
+ * current published one from dist.ipfs.tech/<dist>/<ver>/dist.json
  */
 
 const fs = require('fs')
@@ -18,7 +18,7 @@ require('make-promises-safe') // exit on error
 const RELEASE_PATH = join(__dirname, '..', 'releases')
 const HUGO_DATA_DIR = join(__dirname, '..', 'site', 'data')
 const DIST_PATH = join(__dirname, '..', 'dists')
-const DIST_ROOT = process.env.DIST_ROOT || '/ipns/dist.ipfs.io'
+const DIST_ROOT = process.env.DIST_ROOT || '/ipns/dist.ipfs.tech'
 
 const ipfs = IpfsHttpClient()
 

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -2,7 +2,7 @@
 'use strict'
 
 /*
- * Patch the items in the local releases dir into the current dist.ipfs.io
+ * Patch the items in the local releases dir into the current dist.ipfs.tech
  * For each item
  *   - if it does not exist in dist, add it.
  *   - if it exists and has the same cid, skip it.
@@ -27,7 +27,7 @@ const ipfs = IpfsHttpClient()
 const pathTo = (file) => path.join(__dirname, '..', file)
 
 const event = new Date()
-const DIST_DOMAIN = 'dist.ipfs.io'
+const DIST_DOMAIN = 'dist.ipfs.tech'
 const MFS_DIR = `/${DIST_DOMAIN}/${DIST_DOMAIN}` + '_' + event.toISOString()
 const PATCH_SRC = pathTo('releases')
 const VERSIONS = pathTo('versions')

--- a/site/assets/js/index.js
+++ b/site/assets/js/index.js
@@ -4,8 +4,19 @@ require('bootstrap/dist/js/bootstrap.js')
 require('slicknav/dist/jquery.slicknav.js')
 
 const handlePlatform = require('./platform')
+const maybeRedirectToNewDomain = () => {
+  // https://github.com/protocol/bifrost-infra/issues/2018#issue-1319432302
+  const { href } = window.location
+  if (href.includes('dist.ipfs.io')) {
+    window.location.replace(href.replace('dist.ipfs.io', 'dist.ipfs.tech'))
+  }
+  if (href.includes('dist-ipfs-io')) {
+    window.location.replace(href.replace('dist-ipfs-io', 'dist-ipfs-tech'))
+  }
+}
 
 $(() => {
+  maybeRedirectToNewDomain()
   handlePlatform()
 
   $('#d-navbar').slicknav({

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,4 +1,4 @@
-baseurl = ""
+baseurl = "https://dist.ipfs.tech"
 relativeurls = true
 languageCode = "en-us"
 title = "IPFS Distributions"

--- a/site/layouts/_default/index.xml
+++ b/site/layouts/_default/index.xml
@@ -1,21 +1,20 @@
-{{- $baseURL := "https://dist.ipfs.io" -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ .Site.Title }}</title>
-    <link>{{ $baseURL }}</link>
+    <link>{{ .Site.BaseURL }}</link>
     <description>Recent releases on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>
     {{ with .Site.LanguageCode }}<language>{{.}}</language>{{end}}
     <lastBuildDate>{{ $.Site.Data.siteroot.lastBuildDate | safeHTML }}</lastBuildDate>
     {{ with .OutputFormats.Get "RSS" }}
-	<atom:link href="{{ $baseURL }}{{ .Permalink }}" rel="self" type="{{ .MediaType }}" />
+	<atom:link href="{{ .Permalink }}" rel="self" type="{{ .MediaType }}" />
     {{ end }}
     {{ range $key, $value := $.Site.Data.releases }}
     {{ $data := $value.data }}
     <item>
       <title>{{ $key }}</title>
-      <link>{{ $baseURL }}/#{{ $data.id }}</link>
+      <link>{{ $.Site.BaseURL }}/#{{ $data.id }}</link>
       <pubDate>{{ $data.dateUTC }}</pubDate>
       <description>{{ $data.description | markdownify }}</description>
     </item>

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -8,6 +8,8 @@
     <meta name="description" content="Description">
     <link rel="stylesheet" href="site.css">
     <link rel="icon" type="image/png" href="/img/favicon.png">
+    <link rel="canonical" href="{{ .Permalink | safeURL }}" />
+    <link rel="alternate" type="application/rss+xml" href="{{ $.Site.BaseURL }}/index.xml">
   </head>
   <body data-spy="scroll" data-target="#d-navbar" data-offset="40">
     {{ partial "header.html" }}

--- a/site/layouts/partials/about.md
+++ b/site/layouts/partials/about.md
@@ -1,7 +1,7 @@
 #### Welcome to IPFS Distributions
 
 This is the downloads website for all the official software distributions of the
-[IPFS Project](https://ipfs.io). You can find all the apps, binaries, and
+[IPFS Project](https://ipfs.tech). You can find all the apps, binaries, and
 packages here. Every distribution has a section on this page with ...
 
 * the distribution name and a short description
@@ -14,12 +14,12 @@ packages here. Every distribution has a section on this page with ...
 
 The `All Versions` link on each distribution shows directory listings for all
 the available versions, and a `versions` file
-([example](http://dist.ipfs.io/go-ipfs/versions)). This file can be used by
+([example](http://dist.ipfs.tech/kubo/versions)). This file can be used by
 tools, such as [ipfs-update](#ipfs-update), to find all the available versions
 and download the latest.
 
 The directory listing of each version
-([example](http://dist.ipfs.io/go-ipfs/v0.3.11)) has all the platform archives
+([example](http://dist.ipfs.tech/kubo/v0.14.0)) has all the platform archives
 (`.zip` or `.tar.gz`), a `README.md` and a `dist.json` which describe the
 release for humans and machines. It is meant to be easily consumed and used by
 tools.

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div id="d-header-menu">
       <div class="header-menu-title">
-        <a href="https://ipfs.io" target="_blank" rel="noreferrer noopener"><img src="/img/ipfs-logo.svg" alt="IPFS"></a>
+        <a href="https://ipfs.tech" target="_blank" rel="noreferrer noopener"><img src="/img/ipfs-logo.svg" alt="IPFS"></a>
         <div class="header-menu-subtitle">Distributions</div>
       </div>
     </div>


### PR DESCRIPTION
> Part of https://github.com/protocol/bifrost-infra/issues/2018 and https://github.com/protocol/infra/issues/910 

This needs https://github.com/protocol/bifrost-infra/pull/2043 (will re-run CI when we have TLS cert set up)

## TODO
- [x] rename 
- [x] add canonical link
- [x] add `localtion.replace()` redirect
- [x] keep updating old DNSLink
- [x] set up new DNSLink
  - [x]  https://github.com/protocol/infra/pull/918
  - [x] #717 
- [x] set up TLS cert for dist.ipfs.tech – tracked in https://github.com/protocol/bifrost-infra/pull/2043
- [x] re-run CI on this PR so it reads DIST_ROOT from DNSLink at dist.ipfs.tech