### PR TITLE
feat: dual publish to  /ipns/dist.ipfs.tech

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,12 @@ jobs:
         with:
           name: diff
           path: diff
-      - name: Update DNSLink (if on the main branch)
+      - name: Update .tech DNSLink (if on the main branch)
+        run: npx dnslink-dnsimple --domain dist.ipfs.tech --link /ipfs/${{ steps.cid-reader.outputs.CID }}
+        if: github.ref == 'refs/heads/master'
+        env:
+          DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
+      - name: Update legacy .io DNSLink (if on the main branch)
         run: npx dnslink-dnsimple --domain dist.ipfs.io --link /ipfs/${{ steps.cid-reader.outputs.CID }}
         if: github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION
> Part of https://github.com/protocol/infra/issues/910 and https://github.com/protocol/bifrost-infra/issues/2018 

This PR is extracted from #746 to start publishing under new name without changing anything else.
Dual publishing allows us to evaluate a new name without impacting the old one.

Safe to merge, as it does not change anything yet (the full move will happen in #746).

