### PR TITLE
Use go1.19 in the build pipeline

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 16.15.1
-golang 1.18.5
+golang 1.19.1


### PR DESCRIPTION
I can't release cluster otherwise.