### PR TITLE
Disable ipfs-cluster 32-bit builds.

### DIFF
--- a/dists/ipfs-cluster-follow/build_matrix
+++ b/dists/ipfs-cluster-follow/build_matrix
@@ -1,14 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
-freebsd arm
-openbsd 386
 openbsd amd64
-openbsd arm
-linux 386
 linux amd64
-linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipfs-cluster-service/build_matrix
+++ b/dists/ipfs-cluster-service/build_matrix
@@ -1,14 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
-freebsd arm
-openbsd 386
 openbsd amd64
-openbsd arm
-linux 386
 linux amd64
-linux arm
 linux arm64
-windows 386
 windows amd64


### PR DESCRIPTION
They are broken since the introduction of Pebble.

We can revert this in the future if we add build flags for it etc.