### PR TITLE
feat: kubo builds for arm64

### DIFF
--- a/dists/fs-repo-migrations/build_matrix
+++ b/dists/fs-repo-migrations/build_matrix
@@ -12,3 +12,4 @@ linux arm
 linux arm64
 windows 386
 windows amd64
+windows arm64

--- a/dists/kubo/build_matrix
+++ b/dists/kubo/build_matrix
@@ -12,3 +12,4 @@ linux arm
 linux arm64
 windows 386
 windows amd64
+windows arm64

--- a/templates/build_matrix
+++ b/templates/build_matrix
@@ -12,3 +12,4 @@ linux arm
 linux arm64
 windows 386
 windows amd64
+windows arm64


### PR DESCRIPTION
This is closes https://github.com/ipfs/kubo/issues/9365  by adding ARM64 build target for Windows.

We already provide one for Apple M1 (`darwin arm64`), and
need this for Brave (https://github.com/brave/brave-core-crx-packager/issues/503, cc @mihaiplesa).

- [x] added to kubo
- [x] added to template, so any future migrations will get it as well