### PR TITLE
Fix: use actual repo/package/version to do go mod init

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -451,7 +451,7 @@ function startGoBuilds() {
 		if [ "$GO111MODULE" == "on" ]; then
 		    # Setup version information so we can build with go mod
 		    go mod init "ipfs-distributions"
-		    go mod edit -require "$repo@$(git -C "$repopath" rev-parse HEAD)"
+		    go mod edit -require "$repo/$package@$version"
 		fi
 
 		buildWithMatrix "$matfile" "$repo/$package" "$outputVersion" "$(currentSha "$repopath")" "$buildVersion"


### PR DESCRIPTION
The build process:

  * Sets a custom GOPATH
  * Clones the repo we want to build inside it
  * Does a go mod init and requires the repository we want to build directly (ignoring submodules) by doing a "rev-parse HEAD" on what we cloned
  * Then go-builds the package "go build [...] -mod=mod my.package/abc.

I'm not sure why -mod=mod is updated, but this automatically updates the go.mod when working with submodules (sub-packages) that are tagged separately, to the point that it uses wrong releases (not the checked out one).

This has not been noticed in 4 years because we usually build the last tagged version of things. It you attempt to build a submodule with their own tag while using a tag that is not the latest it will start misbehaving.

This attempts to require exactly what we are trying to build in the go.mod file.