### PR TITLE
feat(ci): use self-hosted runner for faster main build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
+    runs-on: ["self-hosted", "linux", "x64", "2xlarge"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: true # skip if no releases
 
   persist:
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
+    runs-on: ["self-hosted", "linux", "x64", "2xlarge"]
     needs: sign-macos
     environment: Deploy
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON) || fromJSON(github.repository == 'ipfs/distributions' && '["self-hosted", "linux", "x64", "2xlarge"]') || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: true # skip if no releases
 
   persist:
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON) || fromJSON(github.repository == 'ipfs/distributions' && '["self-hosted", "linux", "x64", "2xlarge"]') || '"ubuntu-latest"') }}
     needs: sign-macos
     environment: Deploy
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON) || fromJSON(github.repository == 'ipfs/distributions' && '["self-hosted", "linux", "x64", "2xlarge"]') || '"ubuntu-latest"') }}
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: true # skip if no releases
 
   persist:
-    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON) || fromJSON(github.repository == 'ipfs/distributions' && '["self-hosted", "linux", "x64", "2xlarge"]') || '"ubuntu-latest"') }}
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     needs: sign-macos
     environment: Deploy
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: ["self-hosted", "linux", "x64", "2xlarge"]
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: true # skip if no releases
 
   persist:
-    runs-on: ["self-hosted", "linux", "x64", "2xlarge"]
+    runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     needs: sign-macos
     environment: Deploy
     steps:


### PR DESCRIPTION
The goal is to make it faster, this PR aims to test if using self-hosted runner speeds up release build.

If it is ok, we can decide to set CI_BUILD_RUNS_ON on this repo instead.

cc @galargh  for sanity check +  if we need to safelist this repo somewhere for this to work (i tried to set `CI_BUILD_RUNS_ON` but https://github.com/ipfs/distributions/actions/runs/5799417224/job/15719370344 was stuck waiting for free runner and i cancelled it).