### PR TITLE
chore: update Go to 1.21.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 16.15.1
-golang 1.20.10
+golang 1.21.3


### PR DESCRIPTION
Brings back new Go after #1048. 