### PR TITLE
fix: switch to new dnslink updater

### DIFF
--- a/.github/actions/setup-ipfs/action.yml
+++ b/.github/actions/setup-ipfs/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: ipfs/download-ipfs-distribution-action@v1
       with:
-        name: go-ipfs
+        name: kubo
         version: "${{ env.KUBO_VER }}"
     - uses: ipfs/download-ipfs-distribution-action@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ on:
 
 env:
  DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
- KUBO_VER: 'v0.22.0'       # kubo daemon used for chunking and applying diff
- CLUSTER_CTL_VER: 'v1.0.6' # ipfs-cluster-ctl used for pinning
+ KUBO_VER: 'v0.24.0'       # kubo daemon used for chunking and applying diff
+ CLUSTER_CTL_VER: 'v1.0.7' # ipfs-cluster-ctl used for pinning
 
 jobs:
   build:
@@ -144,17 +144,17 @@ jobs:
         with:
           name: diff
           path: diff
-      - name: Update .tech DNSLink (if on the main branch)
-        run: npx dnslink-dnsimple --domain dist.ipfs.tech --link /ipfs/${{ steps.cid-reader.outputs.CID }}
+      - uses: actions/setup-go@v4
         if: github.ref == 'refs/heads/master'
+        with:
+          go-version: "1.20.x"
+      - name: Update _dnslink.dist.ipfs.tech (if on the main branch)
+        if: github.ref == 'refs/heads/master'
+        run: |
+          go install github.com/ipfs/dnslink-dnsimple@v0.1.0
+          dnslink-dnsimple --domain dist.ipfs.tech  --record _dnslink --link /ipfs/${{ steps.cid-reader.outputs.CID }}
         env:
           DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
-      - name: Update legacy .io DNSLink (if on the main branch)
-        run: npx dnslink-dnsimple --domain dist.ipfs.io --link /ipfs/${{ steps.cid-reader.outputs.CID }}
-        if: github.ref == 'refs/heads/master'
-        env:
-          DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
-
 
   diff:
     needs: persist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,8 @@ on:
 
 env:
  DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
- KUBO_VER: 'v0.22.0'       # kubo daemon used for chunking and applying diff
- CLUSTER_CTL_VER: 'v1.0.6' # ipfs-cluster-ctl used for pinning
+ KUBO_VER: 'v0.24.0'       # kubo daemon used for chunking and applying diff
+ CLUSTER_CTL_VER: 'v1.0.7' # ipfs-cluster-ctl used for pinning
 
 concurrency:
   group: nightly

--- a/package-lock.json
+++ b/package-lock.json
@@ -2951,9 +2951,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001339",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
-      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+      "version": "1.0.30001561",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
+      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
       "dev": true,
       "funding": [
         {
@@ -2963,6 +2963,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -16530,9 +16534,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001339",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
-      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
+      "version": "1.0.30001561",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
+      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
       "dev": true
     },
     "caw": {

--- a/scripts/patch.js
+++ b/scripts/patch.js
@@ -91,7 +91,7 @@ async function addFiles (localPath) {
   const patchRoot = await addFiles(PATCH_SRC)
   console.log(`Patch root is ${patchRoot}`)
 
-  const distRoot = await ipfs.dns(DIST_DOMAIN)
+  const distRoot = await ipfs.resolve(`/ipns/${DIST_DOMAIN}`)
   console.log(`DNSLink for ${DIST_DOMAIN} is ${distRoot}`)
 
   console.log('Patch operations:')


### PR DESCRIPTION
This closes #1053  by switching from old JS tool to newly fixed  (https://github.com/ipfs-shipyard/dnslink-dnsimple/pull/21) GO one (kudos to @ns4plabs).


We will no longer update `.io` version, as it will be CNAMEd to `_dnslink.dist.ipfs.tech` instead.


### TODO

- [x] switch to latest versions of kubo and cluster deps
- [x] test `dnslink-dnsimple@v0.1.0` (go) locally with temporary token
- [x] update CI to use the new `dnslink-dnsimple@v0.1.0` (go) tool
- [x] set CNAME `_dnslink.dist.ipfs.io` to point at `_dnslink.dist.ipfs.tech` so we only need to update .tech from now