### PR TITLE
fix: correct go build error passing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,16 +15,16 @@ on:
         default: '/ipns/dist.ipfs.tech'
 
 env:
- DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
- KUBO_VER: 'v0.24.0'       # kubo daemon used for chunking and applying diff
- CLUSTER_CTL_VER: 'v1.0.7' # ipfs-cluster-ctl used for pinning
+ DIST_ROOT: '/ipfs/QmaSbz55W2q74SzMDYxLuwCwvfYwaHQrz5uHsyzonPUSUH' # TODO ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
+ KUBO_VER: 'v0.26.0'       # kubo daemon used for chunking and applying diff
+ CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
 
 jobs:
   build:
     runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
       - env:
@@ -46,8 +46,8 @@ jobs:
   lint:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
       - run: npm ci --no-audit --progress=false
@@ -57,7 +57,7 @@ jobs:
     runs-on: "macos-latest"
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrieve unsigned artifacts
         uses: actions/download-artifact@v3
         with:
@@ -100,10 +100,10 @@ jobs:
     environment: Deploy
     steps:
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrieve signed artifacts
         uses: actions/download-artifact@v3
         continue-on-error: true # skip if no releases

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
         default: '/ipns/dist.ipfs.tech'
 
 env:
- DIST_ROOT: '/ipfs/QmaSbz55W2q74SzMDYxLuwCwvfYwaHQrz5uHsyzonPUSUH' # TODO ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
+ DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
  KUBO_VER: 'v0.26.0'       # kubo daemon used for chunking and applying diff
  CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: awk 'NR == FNR {f1[$0] = 1; next}; !($0 in f1)' ignored-during-nightly <(ls ./dists -1) > nightlies-to-run
       - id: set-matrix
         run: echo "::set-output name=matrix::$(jq -nc '$ARGS.positional' --args $(cat nightlies-to-run))"
@@ -38,7 +38,7 @@ jobs:
       matrix:
         dist_name: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - env:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}

--- a/build-go.sh
+++ b/build-go.sh
@@ -106,9 +106,10 @@ function goBuild() {
 
 		local output
 		output="$(pwd)/$(basename "$package")$(go env GOEXE)"
-		go build -mod=mod -o "$output" \
-			-trimpath \
-			"${package}"
+		if ! (go build -mod=mod -o "$output" -trimpath "${package}"); then
+			warn "    go build with $package $goos $goarch failed."
+			return 1
+		fi
 
 		if [ -x "$(which glibc-check)" ] && [ "$GOOS" == "linux" ] && [ "$GOARCH" == "amd64" ]; then
 			echo "GLIBC versions:"

--- a/build-go.sh
+++ b/build-go.sh
@@ -107,7 +107,7 @@ function goBuild() {
 		local output
 		output="$(pwd)/$(basename "$package")$(go env GOEXE)"
 		if ! (go build -mod=mod -o "$output" -trimpath "${package}"); then
-			warn "    go build with $package $goos $goarch failed."
+			warn "    go build of $output failed."
 			return 1
 		fi
 
@@ -145,7 +145,7 @@ function doBuild() {
 
 	mkdir -p "$dir"
 
-	if ! (cd "$build_dir_name" && goBuild "$package" "$goos" "$goarch") > build-log; then
+	if ! (cd "$build_dir_name" && goBuild "$package" "$goos" "$goarch") > "$build_dir_name/build-log" 2>&1; then
 		local logfi="$dir/build-log-$goos-$goarch"
 		cp "$build_dir_name/build-log" "$logfi"
 		warn "    $binname failed. logfile at '$logfi'"


### PR DESCRIPTION
Aims to Close https://github.com/ipfs/distributions/issues/673

The meta reason is the entire build pipeline not being written with `set -e`, which means every potential error path needs to be manually handled, or it will be ignored.

For fix here, I suspect things worked fine until we added `glibc-check` here, which made `go build` no longer be the last command in `goBuild`, and if `go build` fails its code is not the code returned by `goBuild`, but we continue to the next command, which may run ok due to no binaries to check :upside_down_face: 

## TODO

- [x] fix the way build-log is created and go build errors are handled
- [x] try to simulate failure on CI and confirm error is handled ok 
- [x] switch back DIST_ROOT to default and merge if passing