### PR TITLE
fix: switch back to go1.22

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 16.15.1
-golang 1.23.0
+golang 1.22.6


### PR DESCRIPTION
Unsafe to use 1.23 until https://github.com/ipfs/kubo/issues/10501 is resolved