### PR TITLE
fix: do not include full path to binary in .sha512 files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
         default: '/ipns/dist.ipfs.tech'
 
 env:
- DIST_ROOT: ${{ github.event.inputs.custom_dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
+ DIST_ROOT: ${{ github.event.inputs.dist_root || '/ipns/dist.ipfs.tech' }} # content root used for calculating diff to build
  KUBO_VER: 'v0.30.0'   # kubo daemon used for chunking and applying diff
  CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
 

--- a/scripts/ci/sign-new-macos-releases.sh
+++ b/scripts/ci/sign-new-macos-releases.sh
@@ -121,18 +121,20 @@ echo "::group::Update changed binaries in ./releases"
             echo "-> Updating $PKG_NAME"
             rm "$PKG_PATH"
             tar -czvf "${WORK_DIR}/releases/${DIST_NAME}/${DIST_VERSION}/$PKG_NAME" -C "${WORK_DIR}/tmp/${DIST_NAME}_${DIST_VERSION}_${arch}-signed/" "${DIST_NAME}"
+	    pushd "${PKG_ROOT}"
             # calculate new hashes
-            NEW_CID=$(ipfs add -Qn "$PKG_PATH")
-            NEW_SHA512_LINE=$(gsha512sum "$PKG_PATH")
+            NEW_CID=$(ipfs add -Qn "$PKG_NAME")
+            NEW_SHA512_LINE=$(gsha512sum "$PKG_NAME")
             NEW_SHA512=$(echo "$NEW_SHA512_LINE" | gawk '{ print $1; }')
             echo "-> New $PKG_NAME"
             echo "   new CID:    $NEW_CID"
             echo "   new SHA512: $NEW_SHA512"
             # update metadata to use new hashes
-            echo "$NEW_CID" > "${PKG_PATH}.cid"
-            echo "$NEW_SHA512_LINE" > "${PKG_PATH}.sha512"
-            gsed -i "s/${OLD_CID}/${NEW_CID}/g; s/${OLD_SHA512}/${NEW_SHA512}/g" "${PKG_ROOT}/dist.json"
+            echo "$NEW_CID" > "${PKG_NAME}.cid"
+            echo "$NEW_SHA512_LINE" > "${PKG_NAME}.sha512"
+            gsed -i "s/${OLD_CID}/${NEW_CID}/g; s/${OLD_SHA512}/${NEW_SHA512}/g" "dist.json"
             echo "-> Completed the update of ${arch}.tar.gz for ${DIST_NAME} ${DIST_VERSION}"
+	    popd
         done
     done
 echo "::endgroup::"


### PR DESCRIPTION
See https://github.com/ipfs/kubo/issues/9323.

This is a darwin release thing because the signature process for macOS means that we recalculate sha512 and cid and we do this using an absolute path so the result includes the path to the file.

The fix is to cd to the folder and do it from there.