### PR TITLE
chore(ci): update artifacts actions to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Inspect git status and contents of ./releases
         run: git status && ls -Rhl ./releases
       - name: Temporarily save ./releases artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: releases-unsigned-diff
           path: releases
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Retrieve unsigned artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: releases-unsigned-diff
           path: releases
@@ -132,7 +132,7 @@ jobs:
       - name: List ./releases after
         run: ls -Rhl ./releases || echo "No ./releases"
       - name: Temporarily save notarized artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: releases-signed-macos-diff
           path: releases
@@ -150,7 +150,7 @@ jobs:
           node-version: '16'
       - uses: actions/checkout@v4
       - name: Retrieve signed artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         continue-on-error: true # skip if no releases
         with:
           name: releases-signed-macos-diff
@@ -186,7 +186,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./dockerized make diff
         if: github.event_name == 'pull_request'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request'
         with:
           name: diff
@@ -208,7 +208,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: diff
       - name: Create comment with the diff


### PR DESCRIPTION
Github sheduled browsouts this month to encourage users to migrate to v4 lets avoid random failues and proactively update