### PR TITLE
chore: remove 386 build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ You can also do `./dockerized <COMAND>`, for instance:
 
 ```
 ./dockerized make clean
-./dockerized ./dist.sh add-version go-ipfs v0.9.0
+./dockerized ./dist.sh add-version kubo v0.33.0
 ./dockerized make publish
 ```
 
-Note that you can't use bash in the command, so 
+Note that you can't use bash in the command, so
 
 ```
-./dockerized make clean && ./dist.sh go-ipfs add-version v0.9.0
+./dockerized make clean && ./dist.sh kubo add-version v0.33.0
 # Does not work
 ```
 and
 
 ```
-./dockerized "make clean && ./dist.sh go-ipfs add-version v0.9.0"
+./dockerized "make clean && ./dist.sh kubo add-version v0.33.0"
 # Does not work
 ```
 
@@ -113,9 +113,9 @@ The optional `sub_package` argument is used to specify a module within a repo.  
 > ./dist.sh new-go-dist fs-repo-99-to-100 github.com/ipfs/fs-repo-migrations fs-repo-99-to-100
 ```
 
-- If the distribution should not show up on the website (e.g. go-ipfs migrations) add a `no-site` file into the `dists/<repo>` folder.
+- If the distribution should not show up on the website (e.g. old kubo migrations) add a `no-site` file into the `dists/<repo>` folder.
 - Manually create a repo-owner file
-- Reminder that for submodules the version numbers will look like fs-repo-x-to-y/v1.0.0
+- Reminder that for submodules the version numbers will look like `fs-repo-x-to-y/v1.0.0`
 
 ### Publishing
 
@@ -163,44 +163,31 @@ Definitions:
 - `<version>` is the version of the `<dist>`.
 - `<platform>` is a supported platform of `<dist>@<version>`
 
-So for example, if we had `<dist>` `go-ipfs` and `fs-repo-migrations`, we might see a hierarchy like:
+So for example, if we had `<dist>` `ipfs-cluster-ctl` we might see a hierarchy like:
 
 ```
 .
-├── fs-repo-migrations
-│   ├── v1.3.0
-│   │   ├── build-info
-│   │   ├── dist.json
-│   │   ├── fs-repo-migrations_v1.3.0_darwin-386.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_darwin-amd64.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_freebsd-386.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_freebsd-amd64.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_freebsd-arm.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_linux-386.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_linux-amd64.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_linux-arm.tar.gz
-│   │   ├── fs-repo-migrations_v1.3.0_windows-386.zip
-│   │   ├── fs-repo-migrations_v1.3.0_windows-amd64.zip
-│   │   └── results
-│   └── versions
-├── go-ipfs
-│   ├── v0.4.9
-│   │   ├── build-info
-│   │   ├── build-log-freebsd-386
-│   │   ├── build-log-freebsd-arm
-│   │   ├── dist.json
-│   │   ├── go-ipfs_v0.4.9_darwin-386.tar.gz
-│   │   ├── go-ipfs_v0.4.9_darwin-amd64.tar.gz
-│   │   ├── go-ipfs_v0.4.9_freebsd-amd64.tar.gz
-│   │   ├── go-ipfs_v0.4.9_linux-386.tar.gz
-│   │   ├── go-ipfs_v0.4.9_linux-amd64.tar.gz
-│   │   ├── go-ipfs_v0.4.9_linux-arm.tar.gz
-│   │   ├── go-ipfs_v0.4.9_windows-386.zip
-│   │   ├── go-ipfs_v0.4.9_windows-amd64.zip
-│   │   └── results
-│   └── versions
-└── index.html
-85 directories, 943 files
+└─── ipfs-cluster-ctl
+   ├── v1.0.8
+   │  ├── build-info
+   │  ├── dist.json
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-amd64.tar.gz
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-amd64.tar.gz.cid
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-amd64.tar.gz.sha512
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-arm64.tar.gz
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-arm64.tar.gz.cid
+   │  ├── ipfs-cluster-ctl_v1.0.8_darwin-arm64.tar.gz.sha512
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-amd64.tar.gz
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-amd64.tar.gz.cid
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-amd64.tar.gz.sha512
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-arm64.tar.gz
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-arm64.tar.gz.cid
+   │  ├── ipfs-cluster-ctl_v1.0.8_linux-arm64.tar.gz.sha512
+   │  ├── ipfs-cluster-ctl_v1.0.8_windows-amd64.zip
+   │  ├── ipfs-cluster-ctl_v1.0.8_windows-amd64.zip.cid
+   │  ├── ipfs-cluster-ctl_v1.0.8_windows-amd64.zip.sha512
+   │  └── results
+   └── versions
 ```
 
 We call this the **distribution index**, the listing of all distributions, their versions, and platform assets.

--- a/dists/fs-repo-0-to-1/build_matrix
+++ b/dists/fs-repo-0-to-1/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/fs-repo-0-to-1/build_matrix
+++ b/dists/fs-repo-0-to-1/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/fs-repo-1-to-2/build_matrix
+++ b/dists/fs-repo-1-to-2/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/fs-repo-1-to-2/build_matrix
+++ b/dists/fs-repo-1-to-2/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/fs-repo-10-to-11/build_matrix
+++ b/dists/fs-repo-10-to-11/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-10-to-11/build_matrix
+++ b/dists/fs-repo-10-to-11/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-11-to-12/build_matrix
+++ b/dists/fs-repo-11-to-12/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-11-to-12/build_matrix
+++ b/dists/fs-repo-11-to-12/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-12-to-13/build_matrix
+++ b/dists/fs-repo-12-to-13/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-12-to-13/build_matrix
+++ b/dists/fs-repo-12-to-13/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-13-to-14/build_matrix
+++ b/dists/fs-repo-13-to-14/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/fs-repo-13-to-14/build_matrix
+++ b/dists/fs-repo-13-to-14/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/fs-repo-14-to-15/build_matrix
+++ b/dists/fs-repo-14-to-15/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/fs-repo-14-to-15/build_matrix
+++ b/dists/fs-repo-14-to-15/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/fs-repo-15-to-16/build_matrix
+++ b/dists/fs-repo-15-to-16/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/fs-repo-15-to-16/build_matrix
+++ b/dists/fs-repo-15-to-16/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/fs-repo-2-to-3/build_matrix
+++ b/dists/fs-repo-2-to-3/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/fs-repo-2-to-3/build_matrix
+++ b/dists/fs-repo-2-to-3/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/fs-repo-3-to-4/build_matrix
+++ b/dists/fs-repo-3-to-4/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/fs-repo-3-to-4/build_matrix
+++ b/dists/fs-repo-3-to-4/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/fs-repo-4-to-5/build_matrix
+++ b/dists/fs-repo-4-to-5/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/fs-repo-4-to-5/build_matrix
+++ b/dists/fs-repo-4-to-5/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/fs-repo-5-to-6/build_matrix
+++ b/dists/fs-repo-5-to-6/build_matrix
@@ -1,8 +1,6 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-5-to-6/build_matrix
+++ b/dists/fs-repo-5-to-6/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-6-to-7/build_matrix
+++ b/dists/fs-repo-6-to-7/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-6-to-7/build_matrix
+++ b/dists/fs-repo-6-to-7/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-7-to-8/build_matrix
+++ b/dists/fs-repo-7-to-8/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-7-to-8/build_matrix
+++ b/dists/fs-repo-7-to-8/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-8-to-9/build_matrix
+++ b/dists/fs-repo-8-to-9/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-8-to-9/build_matrix
+++ b/dists/fs-repo-8-to-9/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-9-to-10/build_matrix
+++ b/dists/fs-repo-9-to-10/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/fs-repo-9-to-10/build_matrix
+++ b/dists/fs-repo-9-to-10/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/fs-repo-migrations/build_matrix
+++ b/dists/fs-repo-migrations/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/fs-repo-migrations/build_matrix
+++ b/dists/fs-repo-migrations/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/go-ipfs/build_matrix
+++ b/dists/go-ipfs/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/go-ipfs/build_matrix
+++ b/dists/go-ipfs/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/gx-go/build_matrix
+++ b/dists/gx-go/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/gx-go/build_matrix
+++ b/dists/gx-go/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/gx/build_matrix
+++ b/dists/gx/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/gx/build_matrix
+++ b/dists/gx/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/ipfs-cluster-ctl/build_matrix
+++ b/dists/ipfs-cluster-ctl/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipfs-cluster-ctl/build_matrix
+++ b/dists/ipfs-cluster-ctl/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/ipfs-cluster-follow/build_matrix
+++ b/dists/ipfs-cluster-follow/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipfs-cluster-follow/build_matrix
+++ b/dists/ipfs-cluster-follow/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/ipfs-cluster-service/build_matrix
+++ b/dists/ipfs-cluster-service/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipfs-cluster-service/build_matrix
+++ b/dists/ipfs-cluster-service/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/ipfs-ds-convert/build_matrix
+++ b/dists/ipfs-ds-convert/build_matrix
@@ -1,6 +1,4 @@
 darwin amd64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 windows amd64

--- a/dists/ipfs-ds-convert/build_matrix
+++ b/dists/ipfs-ds-convert/build_matrix
@@ -1,9 +1,6 @@
 darwin amd64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
-windows 386
 windows amd64

--- a/dists/ipfs-update/build_matrix
+++ b/dists/ipfs-update/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipfs-update/build_matrix
+++ b/dists/ipfs-update/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/ipget/build_matrix
+++ b/dists/ipget/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
-freebsd 386
 freebsd amd64
 freebsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/ipget/build_matrix
+++ b/dists/ipget/build_matrix
@@ -1,7 +1,5 @@
 darwin amd64
 freebsd amd64
-freebsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/dists/kubo/build_matrix
+++ b/dists/kubo/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/dists/kubo/build_matrix
+++ b/dists/kubo/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64

--- a/dists/libp2p-relay-daemon/build_matrix
+++ b/dists/libp2p-relay-daemon/build_matrix
@@ -1,14 +1,10 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64

--- a/dists/libp2p-relay-daemon/build_matrix
+++ b/dists/libp2p-relay-daemon/build_matrix
@@ -1,10 +1,7 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64

--- a/site/config.toml
+++ b/site/config.toml
@@ -11,7 +11,6 @@ hiddenDists = ['go-ipfs', 'gx', 'gx-go', 'libp2p-relay-daemon', 'ipfs-ds-convert
 newGoIpfsName = 'kubo'
 
 [params.targetMap]
-386 = "32-bit"
 amd64 = "64-bit"
 arm = "ARM"
 arm64 = "ARM-64"

--- a/site/config.toml
+++ b/site/config.toml
@@ -12,7 +12,6 @@ newGoIpfsName = 'kubo'
 
 [params.targetMap]
 amd64 = "64-bit"
-arm = "ARM"
 arm64 = "ARM-64"
 
 [params.architectureMap]

--- a/templates/build_matrix
+++ b/templates/build_matrix
@@ -1,11 +1,8 @@
 darwin amd64
 darwin arm64
 freebsd amd64
-freebsd arm
 openbsd amd64
-openbsd arm
 linux amd64
-linux arm
 linux arm64
 windows amd64
 windows arm64

--- a/templates/build_matrix
+++ b/templates/build_matrix
@@ -1,15 +1,11 @@
 darwin amd64
 darwin arm64
-freebsd 386
 freebsd amd64
 freebsd arm
-openbsd 386
 openbsd amd64
 openbsd arm
-linux 386
 linux amd64
 linux arm
 linux arm64
-windows 386
 windows amd64
 windows arm64


### PR DESCRIPTION
Closes #1128 (see rationale there).

This PR does not remove already existing 386 builds, but removes the target from `build_matrix` files to stop building new ones.