### PR TITLE
chore: hide ipfs-update

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -7,7 +7,7 @@ title = "IPFS Distributions"
 taxonomies = {}
 
 [params]
-hiddenDists = ['go-ipfs', 'gx', 'gx-go', 'libp2p-relay-daemon', 'ipfs-ds-convert']
+hiddenDists = ['go-ipfs', 'gx', 'gx-go', 'libp2p-relay-daemon', 'ipfs-ds-convert', 'ipfs-updater']
 newGoIpfsName = 'kubo'
 
 [params.targetMap]

--- a/site/layouts/partials/about.md
+++ b/site/layouts/partials/about.md
@@ -14,12 +14,9 @@ packages here. Every distribution has a section on this page with ...
 
 The `All Versions` link on each distribution shows directory listings for all
 the available versions, and a `versions` file
-([example](http://dist.ipfs.tech/kubo/versions)). This file can be used by
-tools, such as [ipfs-update](#ipfs-update), to find all the available versions
-and download the latest.
+([example](http://dist.ipfs.tech/kubo/versions)).
 
 The directory listing of each version
-([example](http://dist.ipfs.tech/kubo/v0.14.0)) has all the platform archives
+([example](http://dist.ipfs.tech/kubo/v0.33.2)) has all the platform archives
 (`.zip` or `.tar.gz`), a `README.md` and a `dist.json` which describe the
-release for humans and machines. It is meant to be easily consumed and used by
-tools.
+release for humans and machines. Prebuilt binary files for Apple MacOS are signed and notarized.


### PR DESCRIPTION
hiding unmaintained `ipfs-update` from website since we also remove it from docs: https://github.com/ipfs/ipfs-docs/pull/1996