### PR TITLE
chore(ci): update github actions and use node version from .tool-versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
   build:
     runs-on: ${{ fromJSON(vars.CI_BUILD_RUNS_ON || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '16'
+          node-version-file: '.tool-versions'
       - env:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
@@ -56,10 +56,10 @@ jobs:
   lint:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '16'
+          node-version-file: '.tool-versions'
       - run: npm ci --no-audit --progress=false
       - run: npm run lint
 
@@ -75,7 +75,7 @@ jobs:
       # never cancel ongoing notarization, it could be one for master branch
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Retrieve unsigned artifacts
         uses: actions/download-artifact@v4
         with:
@@ -145,10 +145,10 @@ jobs:
     environment: Deploy
     steps:
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '16'
-      - uses: actions/checkout@v4
+          node-version-file: '.tool-versions'
+      - uses: actions/checkout@v5
       - name: Retrieve signed artifacts
         uses: actions/download-artifact@v4
         continue-on-error: true # skip if no releases
@@ -191,7 +191,7 @@ jobs:
         with:
           name: diff
           path: diff
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         if: github.ref == 'refs/heads/master'
         with:
           go-version: "1.20.x"
@@ -212,7 +212,7 @@ jobs:
         with:
           name: diff
       - name: Create comment with the diff
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs').promises

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: awk 'NR == FNR {f1[$0] = 1; next}; !($0 in f1)' ignored-during-nightly <(ls ./dists -1) > nightlies-to-run
       - id: set-matrix
         run: echo "::set-output name=matrix::$(jq -nc '$ARGS.positional' --args $(cat nightlies-to-run))"
@@ -38,7 +38,7 @@ jobs:
       matrix:
         dist_name: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - env:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
@@ -47,7 +47,7 @@ jobs:
       - run: cd ./dists/${{ matrix.dist_name }} && make nightly
       - run: ./dockerized make publish
       - name: Create issue if build failed
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ failure() }}
         with:
           script: |
@@ -98,7 +98,7 @@ jobs:
           GIT_REVISION: ${{ github.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Close any open issues about broken build
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ success() }}
         with:
           script: |


### PR DESCRIPTION
- use node-version-file instead of hardcoded node-version in CI
- update actions/checkout from v4 to v5
- update actions/setup-node from v4 to v5
- update actions/setup-go from v4 to v5
- update actions/github-script from v6 to v7